### PR TITLE
eval transforms error fixed

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -51,7 +51,7 @@ def generate_stem_dataset(data_path, input_size, data_aug):
     ])
 
     test_transform = transforms.Compose([
-        transforms.Resize(input_size),
+        transforms.Resize((input_size,input_size)),
         transforms.ToTensor(),
         transforms.Normalize(tuple(MEAN), tuple(STD))
     ])


### PR DESCRIPTION
-eval method isn't working with single input in transforms.Resize() due to tensors mismatch
_RuntimeError: invalid argument 0: Sizes of tensors must match except in dimension 0. Got 168 and 149 in dimension 3 at /opt/conda/conda-bld/pytorch_1573049306803/work/aten/src/TH/generic/THTensor.cpp:689_